### PR TITLE
Fix normal pleayers being able to generate a plotworld

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -22,7 +22,7 @@ extensions:
 - yaml
 permissions:
     myplot.command:
-        default: true
+        default: op
         children:
             myplot.command.help:
                 default: true


### PR DESCRIPTION
<!-- DO NOT DELETE - LEAVE THIS IN YOUR PR -->
<!-- Welcome to the MyPlot pull request system! -->
<!-- Before you make an issue, make sure your pull request matches the criteria below. -->
<!-- PLEASE TICK THE CHECKBOXES -->
- [x] This PR actually submits something - don't use this system as a messaging service!
- [x] This PR isn't duplicated - you can check if it is by scanning the small list - link is on the navigation bar for this repository.
- [x] This PR includes appropriate markdown for sections - e.g. code blocks for suggested code.
- [x] This PR description and comments in code is understandable - feel free to use your native language to write if you are not comfortable with English.
- [x] This PR has a single branch for itself in your fork - don't just commit to the master branch of your repository!
- [x] This PR has comments written in clear English - please don't write unreadable comments just for your eyes.

<!-- If your PR matches this criteria, hooray! Submit this PR with no worries. If your PR doesn't match this criteria, please consider editing your PR to match it. Thanks for contributing to MyPlots! -->
<!-- PR DESCRIPTION - write a bit about what you've achieved in this pull request. -->
## Pull Request description
This fixes an "exploit" where normal players were able to create plot world and thus fill up the exploited server
<!-- OPTIONAL INFORMATION - use this section for posting crash dumps, backtraces or other files(please use code markdown!) -->
## Optional information
This has been sufficiently tested, normal players can still use the right commands and are blocked from /p generate while ops can use it
