### PR TITLE
Fix #96, optimize getPlotMid

### DIFF
--- a/src/MyPlot/MyPlot.php
+++ b/src/MyPlot/MyPlot.php
@@ -414,14 +414,7 @@ class MyPlot extends PluginBase
 
 		$plotSize = $plotLevel->plotSize;
 		$pos = $this->getPlotPosition($plot);
-		if($plot->X >= 0 and $plot->Z >= 0)
-			$pos->add(floor($plotSize / 2), 1, floor($plotSize / 2));
-		if($plot->X < 0 and $plot->Z > 0)
-			$pos->add(-floor($plotSize / 2), 1, floor($plotSize / 2));
-		if($plot->X > 0 and $plot->Z < 0)
-			$pos->add(floor($plotSize / 2), 1, -floor($plotSize / 2));
-		if($plot->X < 0 and $plot->Z < 0)
-			$pos->add(-floor($plotSize / 2), 1, -floor($plotSize / 2));
+		$pos = new Position($pos->getFloorX() + ($plotSize / 2) + 0.5, $pos->getFloorY() + 1, $pos->getFloorZ() + ($plotSize / 2) + 0.5);
 
 		return $pos;
 	}


### PR DESCRIPTION
<!-- DO NOT DELETE - LEAVE THIS IN YOUR PR -->
<!-- Welcome to the MyPlot pull request system! -->
<!-- Before you make an issue, make sure your pull request matches the criteria below. -->
<!-- PLEASE TICK THE CHECKBOXES -->
- [x] This PR actually submits something - don't use this system as a messaging service!
- [x] This PR isn't duplicated - you can check if it is by scanning the small list - link is on the navigation bar for this repository.
- [x] This PR includes appropriate markdown for sections - e.g. code blocks for suggested code.
- [x] This PR description and comments in code is understandable - feel free to use your native language to write if you are not comfortable with English.
- [x] This PR has a single branch for itself in your fork - don't just commit to the master branch of your repository!
- [x] This PR has comments written in clear English - please don't write unreadable comments just for your eyes.

<!-- If your PR matches this criteria, hooray! Submit this PR with no worries. If your PR doesn't match this criteria, please consider editing your PR to match it. Thanks for contributing to MyPlots! -->
<!-- PR DESCRIPTION - write a bit about what you've achieved in this pull request. -->
## Pull Request description
This PR is a Fix for #96 
- Fix position
- Respect actual mid (+0.5 if uneven plotsize) -> you spawn in the exact center

<!-- OPTIONAL INFORMATION - use this section for posting crash dumps, backtraces or other files(please use code markdown!) -->
## Optional information
{Type something here}
