### PR TITLE
Fix Player can't eat bug

### DIFF
--- a/src/MyPlot/EventListener.php
+++ b/src/MyPlot/EventListener.php
@@ -20,11 +20,11 @@ use pocketmine\event\level\LevelUnloadEvent;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\event\player\PlayerMoveEvent;
+use pocketmine\item\Food;
 use pocketmine\level\Level;
 use pocketmine\Player;
 use pocketmine\utils\Config;
 use pocketmine\utils\TextFormat;
-use pocketmine\item\Food;
 
 class EventListener implements Listener
 {
@@ -112,11 +112,8 @@ class EventListener implements Listener
 	 * @param PlayerInteractEvent $event
 	 */
 	public function onPlayerInteract(PlayerInteractEvent $event) : void {
-		if($event->getItem() instanceof Food){
-			//do nothing
-		}else{
+		if(!$event->getItem() instanceof Food)
 			$this->onEventOnBlock($event);
-		}
 	}
 
 	/**

--- a/src/MyPlot/EventListener.php
+++ b/src/MyPlot/EventListener.php
@@ -112,8 +112,9 @@ class EventListener implements Listener
 	 * @param PlayerInteractEvent $event
 	 */
 	public function onPlayerInteract(PlayerInteractEvent $event) : void {
-		if(!$event->getItem() instanceof Food)
-			$this->onEventOnBlock($event);
+		if(($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK or $event->getAction() === PlayerInteractEvent::RIGHT_CLICK_AIR) and !$event->getItem() instanceof Food)
+			return;
+		$this->onEventOnBlock($event);
 	}
 
 	/**

--- a/src/MyPlot/EventListener.php
+++ b/src/MyPlot/EventListener.php
@@ -24,6 +24,7 @@ use pocketmine\level\Level;
 use pocketmine\Player;
 use pocketmine\utils\Config;
 use pocketmine\utils\TextFormat;
+use pocketmine\item\Food;
 
 class EventListener implements Listener
 {
@@ -111,7 +112,11 @@ class EventListener implements Listener
 	 * @param PlayerInteractEvent $event
 	 */
 	public function onPlayerInteract(PlayerInteractEvent $event) : void {
-		$this->onEventOnBlock($event);
+		if($event->getItem() instanceof Food){
+			//do nothing
+		}else{
+			$this->onEventOnBlock($event);
+		}
 	}
 
 	/**


### PR DESCRIPTION
When a player is into a Plot World, the hungerbar isn't filled when he eat because the Playerinteract Event is cancelled. After the change Food is except from the Event.

- [x] This PR actually submits something - don't use this system as a messaging service!
- [x] This PR isn't duplicated - you can check if it is by scanning the small list - link is on the navigation bar for this repository.
- [x] This PR includes appropriate markdown for sections - e.g. code blocks for suggested code.
- [x] This PR description and comments in code is understandable - feel free to use your native language to write if you are not comfortable with English.
- [x] This PR has a single branch for itself in your fork - don't just commit to the master branch of your repository!
- [x] This PR has comments written in clear English - please don't write unreadable comments just for your eyes.

<!-- If your PR matches this criteria, hooray! Submit this PR with no worries. If your PR doesn't match this criteria, please consider editing your PR to match it. Thanks for contributing to MyPlots! -->
<!-- PR DESCRIPTION - write a bit about what you've achieved in this pull request. -->
## Pull Request description
When a player is into a Plot World, the hungerbar isn't filled when he eat because the Playerinteract Event is cancelled. After the change Food is except from the Event.
