### PR TITLE
Updated KickSubCommand.php to fix bug

### DIFF
--- a/src/MyPlot/subcommand/KickSubCommand.php
+++ b/src/MyPlot/subcommand/KickSubCommand.php
@@ -39,6 +39,10 @@ class KickSubCommand extends SubCommand
 			$sender->sendMessage(TextFormat::RED . $this->translateString("kick.noPlayer"));
 			return true;
 		}
+		if ($this->getPlugin()->getPlotByPosition($target) === null) {
+			$sender->sendMessage(TextFormat::RED . $this->translateString("kick.notInPlot"));
+			return true;
+		}
 		if (!$this->getPlugin()->getPlotByPosition($target)->isSame($plot)) {
 			$sender->sendMessage(TextFormat::RED . $this->translateString("kick.notInPlot"));
 			return true;


### PR DESCRIPTION
## Introduction
Hello, please merge this pr to fix problems with `/p kick` subcommand.
(fixes bug caused if the target player is not inside of any plot) 
### Relevant issues

## Changes
### API changes
no

### Behavioural changes
no

## Backwards compatibility
no

## Follow-up
no

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
Tested the fix, and worked fine for me using the latest version of MyPlot.