### PR TITLE
Remove non-vanilla * from helper and denial systems

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: MyPlot
 main: MyPlot\MyPlot
-version: 1.8.0
+version: 1.9.0
 api:
 - 3.4.0
 authors:

--- a/src/MyPlot/EventListener.php
+++ b/src/MyPlot/EventListener.php
@@ -147,7 +147,7 @@ class EventListener implements Listener
 			$ev->call();
 			$event->setCancelled($ev->isCancelled());
 			$username = $event->getPlayer()->getName();
-			if($plot->owner == $username or $plot->isHelper($username) or $plot->isHelper("*") or $event->getPlayer()->hasPermission("myplot.admin.build.plot")) {
+			if($plot->owner == $username or $plot->isHelper($username) or $event->getPlayer()->hasPermission("myplot.admin.build.plot")) {
 				if(!($event instanceof PlayerInteractEvent and $event->getBlock() instanceof Sapling))
 					return;
 				/*
@@ -179,7 +179,7 @@ class EventListener implements Listener
 				$ev->call();
 				$event->setCancelled($ev->isCancelled());
 				$username = $event->getPlayer()->getName();
-				if($plot->owner == $username or $plot->isHelper($username) or $plot->isHelper("*") or $event->getPlayer()->hasPermission("myplot.admin.build.plot"))
+				if($plot->owner == $username or $plot->isHelper($username) or $event->getPlayer()->hasPermission("myplot.admin.build.plot"))
 					if(!($event instanceof PlayerInteractEvent and $event->getBlock() instanceof Sapling))
 						return;
 			}
@@ -302,7 +302,7 @@ class EventListener implements Listener
 			$ev = new MyPlotPlayerEnterPlotEvent($plot, $player);
 			$ev->setCancelled($event->isCancelled());
 			$username = $player->getName();
-			if($plot->owner !== $username and ($plot->isDenied($username) or $plot->isDenied("*")) and !$player->hasPermission("myplot.admin.denyplayer.bypass")) {
+			if($plot->owner !== $username and $plot->isDenied($username) and !$player->hasPermission("myplot.admin.denyplayer.bypass")) {
 				$ev->setCancelled();
 			}
 			$ev->call();

--- a/src/MyPlot/subcommand/DenyPlayerSubCommand.php
+++ b/src/MyPlot/subcommand/DenyPlayerSubCommand.php
@@ -32,7 +32,7 @@ class DenyPlayerSubCommand extends SubCommand
 		if(empty($args)) {
 			return false;
 		}
-		$dplayer = $args[0];
+		$dplayerName = $args[0];
 		$plot = $this->getPlugin()->getPlotByPosition($sender);
 		if($plot === null) {
 			$sender->sendMessage(TextFormat::RED . $this->translateString("notinplot"));
@@ -42,11 +42,7 @@ class DenyPlayerSubCommand extends SubCommand
 			$sender->sendMessage(TextFormat::RED . $this->translateString("notowner"));
 			return true;
 		}
-		if($dplayer === "*") {
-			$dplayer = new OfflinePlayer(Server::getInstance(), "*");
-			GOTO STAR;
-		}
-		$dplayer = $this->getPlugin()->getServer()->getPlayer($dplayer);
+		$dplayer = $this->getPlugin()->getServer()->getPlayer($dplayerName);
 		if(!$dplayer instanceof Player) {
 			$sender->sendMessage($this->translateString("denyplayer.notaplayer"));
 			return true;
@@ -57,18 +53,12 @@ class DenyPlayerSubCommand extends SubCommand
 				$dplayer->sendMessage($this->translateString("denyplayer.attempteddeny", [$sender->getName()]));
 			return true;
 		}
-		STAR:
 		if($this->getPlugin()->addPlotDenied($plot, $dplayer->getName())) {
 			$sender->sendMessage($this->translateString("denyplayer.success1", [$dplayer->getName()]));
 			if($dplayer instanceof Player) {
 				$dplayer->sendMessage($this->translateString("denyplayer.success2", [$plot->X, $plot->Z, $sender->getName()]));
 			}
-			if($dplayer->getName() === "*") {
-				foreach($this->getPlugin()->getServer()->getOnlinePlayers() as $player) {
-					if($this->getPlugin()->getPlotBB($plot)->isVectorInside($player) and !($player->getName() === $plot->owner) and !$plot->isHelper($player->getName()))
-						$this->getPlugin()->teleportPlayerToPlot($player, $plot);
-				}
-			}elseif($this->getPlugin()->getPlotBB($plot)->isVectorInside($dplayer))
+			if($this->getPlugin()->getPlotBB($plot)->isVectorInside($dplayer))
 				$this->getPlugin()->teleportPlayerToPlot($dplayer, $plot);
 		}else{
 			$sender->sendMessage(TextFormat::RED . $this->translateString("error"));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Recently it was pointed out to me that `@a` would be better to be used in place of the asterisk `*`  because Vanilla bedrock edition uses the `@a` selector. I agree.

The plugin [PlayerSelectors](https://poggit.pmmp.io/p/PlayerSelectors) on poggit can be used to add the `@a` selector along with many other vanilla selectors. This PR removes the `*` implementation in a push for users to use the [PlayerSelectors](https://poggit.pmmp.io/p/PlayerSelectors) plugin instead.

### Relevant issues
<!-- List relevant issues here -->
* N/A

## Changes
#### API changes
<!-- Any additions to the API that should be documented in release notes? -->
* The asterisk `*` can no longer be used with `Plot::isHelper()` or `Plot::isDenied()`

#### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
* The addhelper subcommand can no longer use the asterisk `*` to open a plot to everyone
* The denyplayer subcommand can no longer use the asterisk `*` to block everyone from a plot

#### Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
* Upon updating, plots that had everyone blocked and plots that had everyone helping will no longer function as expected.

### Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
* All Following releases should advertise [PlayerSelectors](https://poggit.pmmp.io/p/PlayerSelectors) as a replacement for the feature.

### Tests
The asterisk`*` no longer functions to allow or block *all* players.