### PR TITLE
Fixed #347

### DIFF
--- a/src/MyPlot/subcommand/SellSubCommand.php
+++ b/src/MyPlot/subcommand/SellSubCommand.php
@@ -33,7 +33,7 @@ class SellSubCommand extends SubCommand
 			$sender->sendMessage(TextFormat::RED . $this->translateString("notinplot"));
 			return true;
 		}
-		if($plot->name !== $sender->getName() and !$sender->hasPermission("myplot.admin.sell")){
+		if($plot->owner !== $sender->getName() and !$sender->hasPermission("myplot.admin.sell")){
 			$sender->sendMessage(TextFormat::RED . $this->translateString("notowner"));
 			return true;
 		}


### PR DESCRIPTION
It was checking for the plot name instead of the plot owner's name...

## Introduction
Do I really need to fill this form?

### Relevant issues
Fixes #347

## Changes
### API changes
/

### Behavioural changes
/

## Backwards compatibility
Backwards compatible.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
Not tested.