### PR TITLE
Prevent Liquids, Grass and Mycelium from spreading over the Plotborder

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -82,6 +82,10 @@ DefaultWorld:
   # This will allow things like water to lag the server in plot worlds
   UpdatePlotLiquids: false
 
+  # Allow plants (e.g. Grass) from spreading to the outside of plots.
+  # This will allow blocks like mycelium to spread from one plot into another
+  AllowOutsidePlotSpread: false
+
   # Edit Border Blocks (Any block immediately adjacent to a plot space)
   # This will allow players to break and place their own border blocks
   EditBorderBlocks: true

--- a/src/MyPlot/EventListener.php
+++ b/src/MyPlot/EventListener.php
@@ -7,7 +7,9 @@ use MyPlot\events\MyPlotBorderChangeEvent;
 use MyPlot\events\MyPlotPlayerEnterPlotEvent;
 use MyPlot\events\MyPlotPlayerLeavePlotEvent;
 use MyPlot\events\MyPlotPvpEvent;
+use pocketmine\block\Grass;
 use pocketmine\block\Liquid;
+use pocketmine\block\Mycelium;
 use pocketmine\block\Sapling;
 use pocketmine\event\block\BlockBreakEvent;
 use pocketmine\event\block\BlockPlaceEvent;
@@ -253,16 +255,24 @@ class EventListener implements Listener
 		if($event->isCancelled()) {
 			return;
 		}
-		if(!$event->getSource() instanceof Liquid)
-			return;
 		$levelName = $event->getBlock()->getLevel()->getFolderName();
 		if(!$this->plugin->isLevelLoaded($levelName))
 			return;
 		$settings = $this->plugin->getLevelSettings($levelName);
-		if(!$settings->updatePlotLiquids and ($this->plugin->getPlotByPosition($event->getBlock()) instanceof Plot or $this->plugin->getPlotByPosition($event->getSource()) instanceof Plot or $this->plugin->isPositionBorderingPlot($event->getBlock()) or $this->plugin->isPositionBorderingPlot($event->getSource()))) {
-			$event->setCancelled();
-			$this->plugin->getLogger()->debug("Cancelled block spread of {$event->getBlock()->getName()} on " . $levelName);
-		}
+		if($event->getSource() instanceof Liquid) {
+		    if (!$settings->updatePlotLiquids and ($this->plugin->getPlotByPosition($event->getBlock()) instanceof Plot or $this->plugin->getPlotByPosition($event->getSource()) instanceof Plot or $this->plugin->isPositionBorderingPlot($event->getBlock()) or $this->plugin->isPositionBorderingPlot($event->getSource()))) {
+		        $event->setCancelled();
+		        $this->plugin->getLogger()->debug("Cancelled block spread of {$event->getSource()->getName()} on " . $levelName);
+		    }elseif ($settings->updatePlotLiquids and ((!$this->plugin->getPlotByPosition($event->getBlock()) instanceof Plot and $this->plugin->getPlotByPosition($event->getSource()) instanceof Plot) or ($this->plugin->getPlotByPosition($event->getBlock()) instanceof Plot and !$this->plugin->getPlotByPosition($event->getSource()) instanceof Plot) or ($this->plugin->isPositionBorderingPlot($event->getBlock()) and !$this->plugin->getPlotByPosition($event->getSource()) instanceof Plot) or ($this->plugin->isPositionBorderingPlot($event->getSource()) and !$this->plugin->getPlotByPosition($event->getBlock()) instanceof Plot))) {
+		        $event->setCancelled();
+		        $this->plugin->getLogger()->debug("Cancelled block spread of {$event->getSource()->getName()} on " . $levelName);
+		    }
+		}elseif ($event->getSource() instanceof Grass or $event->getSource() instanceof Mycelium){
+		    if ((!$this->plugin->getPlotByPosition($event->getBlock()) instanceof Plot and $this->plugin->getPlotByPosition($event->getSource()) instanceof Plot) or !$this->plugin->getPlotByPosition($event->getSource()) instanceof Plot) {
+		        $event->setCancelled();
+		        $this->plugin->getLogger()->debug("Cancelled block spread of {$event->getSource()->getName()} on " . $levelName);
+            }
+        }
 	}
 
 	/**

--- a/src/MyPlot/PlotLevelSettings.php
+++ b/src/MyPlot/PlotLevelSettings.php
@@ -40,6 +40,8 @@ class PlotLevelSettings
 	public $restrictPVP = false;
 	/** @var bool $updatePlotLiquids */
 	public $updatePlotLiquids = false;
+	/** @var bool $allowOutsidePlotSpread */
+	public $allowOutsidePlotSpread = false;
 	/** @var bool $displayDoneNametags */
 	public $displayDoneNametags = false;
 	/** @var bool $editBorderBlocks */
@@ -70,6 +72,7 @@ class PlotLevelSettings
 			$this->restrictEntityMovement = self::parseBool($settings, "RestrictEntityMovement", true);
 			$this->restrictPVP = self::parseBool($settings, "RestrictPVP", false);
 			$this->updatePlotLiquids = self::parseBool($settings, "UpdatePlotLiquids", false);
+			$this->allowOutsidePlotSpread = self::parseBool($settings, "AllowOutsidePlotSpread", false);
 			$this->editBorderBlocks = self::parseBool($settings, "EditBorderBlocks", true);
 		}
 	}


### PR DESCRIPTION
This prevents Liquids, Grass and Mycelium from spreading over the PlotBorder from Plotside and Streetside.
This prevents, for example, Grass or Mycelium from spreading on dirt roads from a Plot all over the Plotworld