### PR TITLE
Fix crash when generating a new plots world. (#385)

### DIFF
--- a/src/MyPlot/EventListener.php
+++ b/src/MyPlot/EventListener.php
@@ -74,7 +74,7 @@ class EventListener implements Listener
 				$prop = $ref->getProperty('randomTickBlocks');
 				$prop->setAccessible(true);
 				/** @var \SplFixedArray $randomTickBlocks */
-				$randomTickBlocks = $prop->getValue();
+				$randomTickBlocks = $prop->getValue($event->getLevel());
 				$randomTickBlocks->offsetUnset(BlockIds::FIRE);
 				$prop->setValue($randomTickBlocks, $event->getLevel());
 			}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
#385 - Internal Server error when a player creates a new plot world. ReflectionProperty->getValue() requires 1 parameter, 0 were passed in EventListener at line 77. It says that the value can be null, but that was added in PHP 8.0

Changed lien 77 in EventListener from
```php
$randomTickBlocks = $prop->getValue();
```
to
```php
$randomTickBlocks = $prop->getValue($event->getLevel());
```

## Changes
### API changes
none

### Behavioural changes
none

## Backwards compatibility
none

## Follow-up
none

## Tests
Ran ``/plot generate myplots`` with no changes and crashed. When I changed the line I was able to generate the world successfully. 