### PR TITLE
BC Break: Scrap the whole plot id system

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: MyPlot
 main: MyPlot\MyPlot
-version: 1.11.1
+version: 2.0.0
 api:
 - 3.4.0
 authors:

--- a/src/MyPlot/MyPlot.php
+++ b/src/MyPlot/MyPlot.php
@@ -539,11 +539,6 @@ class MyPlot extends PluginBase
 			return false;
 		}
 		foreach ($toMerge as $pair) {
-
-			//if ($pair[1]->id === -1) {
-			//	$this->getLogger()->debug("Failed to merge due to invalid Id");
-			//	return false;
-			//} else
 			if ($pair[1]->owner === "") {
 				$this->getLogger()->debug("Failed to merge due to plot not claimed");
 				return false;

--- a/src/MyPlot/Plot.php
+++ b/src/MyPlot/Plot.php
@@ -26,8 +26,6 @@ class Plot
 	public $pvp = true;
 	/** @var float $price */
 	public $price = 0.0;
-	/** @var int $id */
-	public $id = -1;
 
 	/**
 	 * Plot constructor.
@@ -42,9 +40,8 @@ class Plot
 	 * @param string $biome
 	 * @param bool|null $pvp
 	 * @param float $price
-	 * @param int $id
 	 */
-	public function __construct(string $levelName, int $X, int $Z, string $name = "", string $owner = "", array $helpers = [], array $denied = [], string $biome = "PLAINS", ?bool $pvp = null, float $price = -1, int $id = -1) {
+	public function __construct(string $levelName, int $X, int $Z, string $name = "", string $owner = "", array $helpers = [], array $denied = [], string $biome = "PLAINS", ?bool $pvp = null, float $price = -1) {
 		$this->levelName = $levelName;
 		$this->X = $X;
 		$this->Z = $Z;
@@ -63,7 +60,6 @@ class Plot
 			$this->price = $price < 0 ? $settings->claimPrice : $price;
 		else
 			$this->price = 0;
-		$this->id = $id;
 	}
 
 	/**

--- a/src/MyPlot/provider/ConfigDataProvider.php
+++ b/src/MyPlot/provider/ConfigDataProvider.php
@@ -50,7 +50,7 @@ class ConfigDataProvider extends DataProvider {
 			return $plot;
 		}
 		$plots = (array)$this->config->get("plots", []);
-		$key = $plot->levelName.';'.$plot->X.';'.$plot->Z;
+		$key = $levelName.';'.$X.';'.$Z;
 		if(isset($plots[$key])) {
 			$plotName = (string)$plots[$key]["name"];
 			$owner = (string)$plots[$key]["owner"];

--- a/src/MyPlot/provider/MySQLProvider.php
+++ b/src/MyPlot/provider/MySQLProvider.php
@@ -54,9 +54,13 @@ class MySQLProvider extends DataProvider {
 		if($this->db->connect_error !== null and $this->db->connect_error !== '')
 			throw new \RuntimeException("Failed to connect to the MySQL database: " . $this->db->connect_error);
 		$this->db->query("CREATE TABLE IF NOT EXISTS plotsV2 (level TEXT, X INT, Z INT, name TEXT, owner TEXT, helpers TEXT, denied TEXT, biome TEXT, pvp INT, price FLOAT, PRIMARY KEY (level, X, Z));");
-		$this->db->query("INSERT IGNORE INTO plotsV2 (level, X, Z, name, owner, helpers, denied, biome, pvp, price) SELECT level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plots;");
+		$res = $this->db->query("SELECT count(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA='{$settings['DatabaseName']}' AND TABLE_NAME='plots'");
+		if($res instanceof \mysqli_result and $res->fetch_array()[0] > 0)
+			$this->db->query("INSERT IGNORE INTO plotsV2 (level, X, Z, name, owner, helpers, denied, biome, pvp, price) SELECT level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plots;");
 		$this->db->query("CREATE TABLE IF NOT EXISTS mergedPlotsV2 (level TEXT, originX INT, originZ INT, mergedX INT, mergedZ INT, PRIMARY KEY(level, originX, originZ, mergedX, mergedZ));");
-		$this->db->query("INSERT IGNORE INTO mergedPlotsV2 (level, originX, originZ, mergedX, mergedZ) SELECT r1.level, r1.X, r1.Z, r2.X, r2.Z FROM plots r1, mergedPlots JOIN plots r2 ON r1.id = mergedPlots.originId AND r2.id = mergedPlots.mergedId;");
+		$res = $this->db->query("SELECT count(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA='{$settings['DatabaseName']}' AND TABLE_NAME='mergedPlots';");
+		if($res instanceof \mysqli_result and $res->fetch_array()[0] > 0)
+			$this->db->query("INSERT IGNORE INTO mergedPlotsV2 (level, originX, originZ, mergedX, mergedZ) SELECT r1.level, r1.X, r1.Z, r2.X, r2.Z FROM plots r1, mergedPlots JOIN plots r2 ON r1.id = mergedPlots.originId AND r2.id = mergedPlots.mergedId;");
 		$this->prepare();
 		$this->plugin->getLogger()->debug("MySQL data provider registered");
 	}

--- a/src/MyPlot/provider/SQLiteDataProvider.php
+++ b/src/MyPlot/provider/SQLiteDataProvider.php
@@ -43,7 +43,9 @@ class SQLiteDataProvider extends DataProvider
 		$this->db->exec("CREATE TABLE IF NOT EXISTS plotsV2
 			(level TEXT, X INTEGER, Z INTEGER, name TEXT,
 			 owner TEXT, helpers TEXT, denied TEXT, biome TEXT, pvp INTEGER, price FLOAT, PRIMARY KEY (level, X, Z));");
-		$this->db->exec("INSERT OR ABORT INTO plotsV2 (level, X, Z, name, owner, helpers, denied, biome, pvp, price) SELECT level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plots;");
+		$this->db->exec("INSERT OR IGNORE INTO plotsV2 (level, X, Z, name, owner, helpers, denied, biome, pvp, price) SELECT level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plots;");
+		$this->db->exec("CREATE TABLE IF NOT EXISTS mergedPlotsV2 (level TEXT, originX INTEGER, originZ INTEGER, mergedX INTEGER, mergedZ INTEGER, PRIMARY KEY(level, originX, originZ, mergedX, mergedZ));");
+		$this->db->exec("INSERT OR IGNORE INTO mergedPlotsV2 (level, originX, originZ, mergedX, mergedZ) SELECT r1.level, r1.X, r1.Z, r2.X, r2.Z FROM plots r1, mergedPlots JOIN plots r2 ON r1.id = mergedPlots.originId AND r2.id = mergedPlots.mergedId;");
 		$this->prepare();
 		$this->plugin->getLogger()->debug("SQLite data provider registered");
 	}
@@ -314,7 +316,6 @@ class SQLiteDataProvider extends DataProvider
 		if($stmt === false)
 			throw new \Exception();
 		$this->sqlGetExistingXZ = $stmt;
-		$this->db->exec("CREATE TABLE IF NOT EXISTS mergedPlotsV2 (level TEXT, originX INTEGER, originZ INTEGER, mergedX INTEGER, mergedZ INTEGER, PRIMARY KEY(level, originX, originZ, mergedX, mergedZ));");
 		$stmt = $this->db->prepare("INSERT OR REPLACE INTO mergedPlotsV2 (level, originX, originZ, mergedX, mergedZ) VALUES (:level, :originX, :originZ, :mergedX, :mergedZ);");
 		if($stmt === false)
 			throw new \Exception();

--- a/src/MyPlot/provider/SQLiteDataProvider.php
+++ b/src/MyPlot/provider/SQLiteDataProvider.php
@@ -43,53 +43,7 @@ class SQLiteDataProvider extends DataProvider
 		$this->db->exec("CREATE TABLE IF NOT EXISTS plots
 			(level TEXT, X INTEGER, Z INTEGER, name TEXT,
 			 owner TEXT, helpers TEXT, denied TEXT, biome TEXT, pvp INTEGER, price FLOAT, PRIMARY KEY (level, X, Z));");
-		$stmt = $this->db->prepare("SELECT name, owner, helpers, denied, biome, pvp, price FROM plots WHERE level = :level AND X = :X AND Z = :Z;");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlGetPlot = $stmt;
-		$stmt = $this->db->prepare("INSERT OR REPLACE INTO plots (level, X, Z, name, owner, helpers, denied, biome, pvp, price) VALUES (:level, :X, :Z, :name, :owner, :helpers, :denied, :biome, :pvp, :price);");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlSavePlot = $stmt;
-		$stmt = $this->db->prepare("DELETE FROM plots WHERE level = :level AND X = :X AND Z = :Z;");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlRemovePlot = $stmt;
-		$stmt = $this->db->prepare("UPDATE plots SET name = '', owner = '', helpers = '', denied = '', biome = :biome, pvp = :pvp, price = :price WHERE level = :level AND X = :X AND Z = :Z;");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlDisposeMergedPlot = $stmt;
-		$stmt = $this->db->prepare("SELECT * FROM plots WHERE owner = :owner;");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlGetPlotsByOwner = $stmt;
-		$stmt = $this->db->prepare("SELECT * FROM plots WHERE owner = :owner AND level = :level;");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlGetPlotsByOwnerAndLevel = $stmt;
-		$stmt = $this->db->prepare("SELECT X, Z FROM plots WHERE (
-				level = :level
-				AND (
-					(abs(X) = :number AND abs(Z) <= :number) OR
-					(abs(Z) = :number AND abs(X) <= :number)
-				)
-			);");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlGetExistingXZ = $stmt;
-		$this->db->exec("CREATE TABLE IF NOT EXISTS mergedPlotsV2 (level TEXT, originX INTEGER, originZ INTEGER, mergedX INTEGER, mergedZ INTEGER, PRIMARY KEY(level, originX, originZ, mergedX, mergedZ));");
-		$stmt = $this->db->prepare("INSERT OR REPLACE INTO mergedPlotsV2 (level, originX, originZ, mergedX, mergedZ) VALUES (:level, :originX, :originZ, :mergedX, :mergedZ);");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlMergePlot = $stmt;
-		$stmt = $this->db->prepare("SELECT plots.level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plots LEFT JOIN mergedPlotsV2 ON mergedPlotsV2.level = plots.level WHERE mergedPlotsV2.level = :level AND mergedX = :mergedX AND mergedZ = :mergedZ;");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlGetMergeOrigin = $stmt;
-		$stmt = $this->db->prepare("SELECT plots.level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plots LEFT JOIN mergedPlotsV2 ON mergedPlotsV2.level = plots.level AND mergedPlotsV2.mergedX = plots.X AND mergedPlotsV2.mergedZ = plots.Z WHERE mergedPlotsV2.level = :level AND originX = :originX AND originZ = :originZ;");
-		if($stmt === false)
-			throw new \Exception();
-		$this->sqlGetMergedPlots = $stmt;
+		$this->prepare();
 		$this->plugin->getLogger()->debug("SQLite data provider registered");
 	}
 
@@ -329,5 +283,55 @@ class SQLiteDataProvider extends DataProvider
 			return new Plot((string) $val["level"], (int) $val["X"], (int) $val["Z"], (string) $val["name"], (string) $val["owner"], $helpers, $denied, (string) $val["biome"], $pvp, (float) $val["price"]);
 		}
 		return $plot;
+	}
+
+	private function prepare() : void {
+		$stmt = $this->db->prepare("SELECT name, owner, helpers, denied, biome, pvp, price FROM plotsV2 WHERE level = :level AND X = :X AND Z = :Z;");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlGetPlot = $stmt;
+		$stmt = $this->db->prepare("INSERT OR REPLACE INTO plotsV2 (level, X, Z, name, owner, helpers, denied, biome, pvp, price) VALUES (:level, :X, :Z, :name, :owner, :helpers, :denied, :biome, :pvp, :price);");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlSavePlot = $stmt;
+		$stmt = $this->db->prepare("DELETE FROM plotsV2 WHERE level = :level AND X = :X AND Z = :Z;");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlRemovePlot = $stmt;
+		$stmt = $this->db->prepare("UPDATE plotsV2 SET name = '', owner = '', helpers = '', denied = '', biome = :biome, pvp = :pvp, price = :price WHERE level = :level AND X = :X AND Z = :Z;");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlDisposeMergedPlot = $stmt;
+		$stmt = $this->db->prepare("SELECT * FROM plotsV2 WHERE owner = :owner;");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlGetPlotsByOwner = $stmt;
+		$stmt = $this->db->prepare("SELECT * FROM plotsV2 WHERE owner = :owner AND level = :level;");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlGetPlotsByOwnerAndLevel = $stmt;
+		$stmt = $this->db->prepare("SELECT X, Z FROM plotsV2 WHERE (
+				level = :level
+				AND (
+					(abs(X) = :number AND abs(Z) <= :number) OR
+					(abs(Z) = :number AND abs(X) <= :number)
+				)
+			);");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlGetExistingXZ = $stmt;
+		$this->db->exec("CREATE TABLE IF NOT EXISTS mergedPlotsV2 (level TEXT, originX INTEGER, originZ INTEGER, mergedX INTEGER, mergedZ INTEGER, PRIMARY KEY(level, originX, originZ, mergedX, mergedZ));");
+		$stmt = $this->db->prepare("INSERT OR REPLACE INTO mergedPlotsV2 (level, originX, originZ, mergedX, mergedZ) VALUES (:level, :originX, :originZ, :mergedX, :mergedZ);");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlMergePlot = $stmt;
+		$stmt = $this->db->prepare("SELECT plotsV2.level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plotsV2 LEFT JOIN mergedPlotsV2 ON mergedPlotsV2.level = plotsV2.level WHERE mergedPlotsV2.level = :level AND mergedX = :mergedX AND mergedZ = :mergedZ;");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlGetMergeOrigin = $stmt;
+		$stmt = $this->db->prepare("SELECT plotsV2.level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plotsV2 LEFT JOIN mergedPlotsV2 ON mergedPlotsV2.level = plotsV2.level AND mergedPlotsV2.mergedX = plotsV2.X AND mergedPlotsV2.mergedZ = plotsV2.Z WHERE mergedPlotsV2.level = :level AND originX = :originX AND originZ = :originZ;");
+		if($stmt === false)
+			throw new \Exception();
+		$this->sqlGetMergedPlots = $stmt;
 	}
 }

--- a/src/MyPlot/provider/SQLiteDataProvider.php
+++ b/src/MyPlot/provider/SQLiteDataProvider.php
@@ -43,9 +43,11 @@ class SQLiteDataProvider extends DataProvider
 		$this->db->exec("CREATE TABLE IF NOT EXISTS plotsV2
 			(level TEXT, X INTEGER, Z INTEGER, name TEXT,
 			 owner TEXT, helpers TEXT, denied TEXT, biome TEXT, pvp INTEGER, price FLOAT, PRIMARY KEY (level, X, Z));");
-		$this->db->exec("INSERT OR IGNORE INTO plotsV2 (level, X, Z, name, owner, helpers, denied, biome, pvp, price) SELECT level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plots;");
+		if($this->db->querySingle("SELECT name FROM sqlite_Master WHERE type='table' AND name='plots';") > 0)
+			$this->db->exec("INSERT OR IGNORE INTO plotsV2 (level, X, Z, name, owner, helpers, denied, biome, pvp, price) SELECT level, X, Z, name, owner, helpers, denied, biome, pvp, price FROM plots;");
 		$this->db->exec("CREATE TABLE IF NOT EXISTS mergedPlotsV2 (level TEXT, originX INTEGER, originZ INTEGER, mergedX INTEGER, mergedZ INTEGER, PRIMARY KEY(level, originX, originZ, mergedX, mergedZ));");
-		$this->db->exec("INSERT OR IGNORE INTO mergedPlotsV2 (level, originX, originZ, mergedX, mergedZ) SELECT r1.level, r1.X, r1.Z, r2.X, r2.Z FROM plots r1, mergedPlots JOIN plots r2 ON r1.id = mergedPlots.originId AND r2.id = mergedPlots.mergedId;");
+		if($this->db->querySingle("SELECT name FROM sqlite_Master WHERE type='table' AND name='mergedPlots';") > 0)
+			$this->db->exec("INSERT OR IGNORE INTO mergedPlotsV2 (level, originX, originZ, mergedX, mergedZ) SELECT r1.level, r1.X, r1.Z, r2.X, r2.Z FROM plots r1, mergedPlots JOIN plots r2 ON r1.id = mergedPlots.originId AND r2.id = mergedPlots.mergedId;");
 		$this->prepare();
 		$this->plugin->getLogger()->debug("SQLite data provider registered");
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The id system is very broken as things stand, so this PR serves to change to a more accurate system which identifies plots by their world, X, and Z values.

### Relevant issues
<!-- List relevant issues here -->
N/A

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Plot::$id no longer exists and the id field has been removed from the class constructor.

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
Plot Merging is more reliable by using the coordinates directly.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Tables are automatically upgraded without dropping legacy tables for reversion support.
Plot::$id no longer exists and the id field has been removed from the class constructor.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Legacy SQL tables will be fully dropped in a future update.