### PR TITLE
fix for Issue #399 and #415

### DIFF
--- a/src/MyPlot/provider/MySQLProvider.php
+++ b/src/MyPlot/provider/MySQLProvider.php
@@ -86,6 +86,9 @@ class MySQLProvider extends DataProvider {
 			$this->plugin->getLogger()->error($stmt->error);
 			return false;
 		}
+		if($plot->id < 0) {
+		    $plot->id = $this->db->insert_id;
+		}
 		$this->cachePlot($plot);
 		return true;
 	}

--- a/src/MyPlot/provider/MySQLProvider.php
+++ b/src/MyPlot/provider/MySQLProvider.php
@@ -57,7 +57,7 @@ class MySQLProvider extends DataProvider {
 		parent::__construct($plugin, $cacheSize);
 		$this->settings = $settings;
 		$this->db = new \mysqli($settings['Host'], $settings['Username'], $settings['Password'], $settings['DatabaseName'], $settings['Port']);
-		if($this->db->connect_error !== '')
+		if($this->db->connect_error !== null)
 			throw new \RuntimeException("Failed to connect to the MySQL database: " . $this->db->connect_error);
 		$this->db->query("CREATE TABLE IF NOT EXISTS plots (id INT PRIMARY KEY AUTO_INCREMENT, level TEXT, X INT, Z INT, name TEXT, owner TEXT, helpers TEXT, denied TEXT, biome TEXT, pvp INT, price FLOAT);");
 		try{

--- a/src/MyPlot/provider/MySQLProvider.php
+++ b/src/MyPlot/provider/MySQLProvider.php
@@ -66,6 +66,7 @@ class MySQLProvider extends DataProvider {
 		try{
 			$this->db->query("ALTER TABLE plots ADD COLUMN price FLOAT AFTER pvp;");
 		}catch(\Exception $e) {}
+		$this->db->query("CREATE TABLE IF NOT EXISTS mergedPlots (originId INTEGER, mergedId INTEGER UNIQUE, PRIMARY KEY (originId, mergedId), FOREIGN KEY (originId) REFERENCES plots (id) ON DELETE CASCADE , FOREIGN KEY (mergedId) REFERENCES plots (id) ON DELETE CASCADE);");
 		$this->prepare();
 		$this->plugin->getLogger()->debug("MySQL data provider registered");
 	}

--- a/src/MyPlot/provider/SQLiteDataProvider.php
+++ b/src/MyPlot/provider/SQLiteDataProvider.php
@@ -145,6 +145,9 @@ class SQLiteDataProvider extends DataProvider
 		if(!$result instanceof \SQLite3Result) {
 			return false;
 		}
+		if($plot->id < 0) {
+		    $plot->id = $this->db->lastInsertRowID();
+		}
 		$this->cachePlot($plot);
 		return true;
 	}


### PR DESCRIPTION
Without this Check, the wrong Plot-ID is saved in the Plot-Cache
At the point where the plots are to be merged, the wrong ID is taken from the cache into the Database

Added:
Change the check of "connect_error" at MysqlProvider.
Connect_error returns NULL instead of a empty String when everything is ok

Added:
Creating of Table "mergedPlots" is missing in MysqlProvider (also Issue #415 )