### PR TITLE
Fixed bug with `/plot setowner`

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -123,6 +123,8 @@ permissions:
     default: op
   myplot.admin.buy:
     default: op
+  myplot.admin.setowner:
+    default: op
   myplot.claimplots:
     default: op
   myplot.claimplots.2:


### PR DESCRIPTION
The `/plot setowner`-command isn't working because the permission for the command isn't registered. This PR will fix that.